### PR TITLE
Add missing require

### DIFF
--- a/lib/json_rpc_handler.rb
+++ b/lib/json_rpc_handler.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'json_rpc_handler/version'
+require 'json'
 
 module JsonRpcHandler
   class Version


### PR DESCRIPTION
This gem uses `json`, but does not `require` it now. This PR adds it.

In the test, `simplecov` loads `json`. So it was passed. If we comment out `simplecov`, the test would fail like the following.

```
  1) Error:
JsonRpcHandler::#handle#test_0016_returns an error with the code set to -32700 there is a JSON parse error:
NameError: uninitialized constant JsonRpcHandler::JSON
    lib/json_rpc_handler.rb:54:in 'JsonRpcHandler.handle_json'
    test/json_rpc_handler_test.rb:472:in 'handle_json'
    test/json_rpc_handler_test.rb:284:in 'block (3 levels) in <top (required)>'

  2) Error:
JsonRpcHandler::#handle_json#test_0002_returns nil for notifications:
NoMethodError: undefined method 'to_json' for an instance of Hash
    test/json_rpc_handler_test.rb:449:in 'block (3 levels) in <top (required)>'

  3) Error:
JsonRpcHandler::#handle_json#test_0001_returns a Response object when the request is valid and not a notification:
NoMethodError: undefined method 'to_json' for an instance of Hash
    test/json_rpc_handler_test.rb:441:in 'block (3 levels) in <top (required)>'

  4) Error:
JsonRpcHandler::#handle_json#test_0003_returns an error with the id set to nil when the request is invalid:
NoMethodError: undefined method 'to_json' for an instance of Hash
    test/json_rpc_handler_test.rb:455:in 'block (3 levels) in <top (required)>'
```