### PR TITLE
ensure request ids contain alphanumerics,dashes,underscores

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,54 @@ method returned `nil`, or all method calls of a batch request returned `nil`. It
 is up to the integration to apply the appropriate transport-layer semantics
 (e.g. returning a 204 No Content).
 
+### ID Validation
+
+By default, string request IDs are validated to contain only alphanumeric
+characters, dashes, and underscores.
+
+**Note:** The JSON-RPC 2.0 specification does not specify a default ID validation pattern, but this default validation
+is recommended to protect against XSS vulnerabilities when IDs are reflected in responses.
+
+```rb
+# Default behavior - accepts alphanumerics, dashes, underscores
+request = { jsonrpc: '2.0', id: 'request-123_abc', method: 'add', params: {a: 1, b: 2} }
+JsonRpcHandler.handle(request) { |method_name| ... }
+# => {"jsonrpc":"2.0","id":"request-123_abc","result":3}
+
+# Rejects potentially dangerous characters
+request = { jsonrpc: '2.0', id: '<script>alert("xss")</script>', method: 'add', params: {a: 1, b: 2} }
+JsonRpcHandler.handle(request) { |method_name| ... }
+# => {"jsonrpc":"2.0","id":null,"error":{"code":-32600,"message":"Invalid Request","data":"Request ID must match validation pattern, or be an integer or null"}}
+```
+
+You can customize the validation pattern by passing the `id_validation_pattern`
+parameter:
+
+```rb
+# Allow email-like IDs with a custom pattern
+custom_pattern = /\A[a-zA-Z0-9_.\-@]+\z/
+request = { jsonrpc: '2.0', id: 'user@example.com', method: 'add', params: {a: 1, b: 2} }
+
+JsonRpcHandler.handle(request, id_validation_pattern: custom_pattern) do |method_name|
+  # ...
+end
+
+# Also works with handle_json
+JsonRpcHandler.handle_json(request_json, id_validation_pattern: custom_pattern) do |method_name|
+  # ...
+end
+```
+
+To disable ID validation entirely (not recommended), pass
+`nil` as the pattern:
+
+```rb
+# Accepts any string
+JsonRpcHandler.handle(request, id_validation_pattern: nil) do |method_name|
+  # ...
+end
+```
+
 ## Development
 
 After checking out the repo:

--- a/lib/json_rpc_handler.rb
+++ b/lib/json_rpc_handler.rb
@@ -17,18 +17,21 @@ module JsonRpcHandler
     ParseError = -32700
   end
 
+  DEFAULT_ALLOWED_ID_CHARACTERS = /\A[a-zA-Z0-9_-]+\z/.freeze
+
   module_function
 
-  def handle(request, &method_finder)
+  def handle(request, id_validation_pattern: DEFAULT_ALLOWED_ID_CHARACTERS, &method_finder)
+
     if request.is_a? Array
-      return error_response id: :unknown_id, error: {
+      return error_response id: :unknown_id, id_validation_pattern:, error: {
         code: ErrorCode::InvalidRequest,
         message: 'Invalid Request',
         data: 'Request is an empty array',
       } if request.empty?
 
       # Handle batch requests
-      responses = request.map { |req| process_request req, &method_finder }.compact
+      responses = request.map { |req| process_request req, id_validation_pattern:, &method_finder }.compact
 
       # A single item is hoisted out of the array
       return responses.first if responses.one?
@@ -37,9 +40,9 @@ module JsonRpcHandler
       responses if responses.any?
     elsif request.is_a? Hash
       # Handle single request
-      process_request request, &method_finder
+      process_request request, id_validation_pattern:, &method_finder
     else
-      error_response id: :unknown_id, error: {
+      error_response id: :unknown_id, id_validation_pattern:, error: {
         code: ErrorCode::InvalidRequest,
         message: 'Invalid Request',
         data: 'Request must be an array or a hash',
@@ -47,12 +50,12 @@ module JsonRpcHandler
     end
   end
 
-  def handle_json(request_json, &method_finder)
+  def handle_json(request_json, id_validation_pattern: DEFAULT_ALLOWED_ID_CHARACTERS, &method_finder)
     begin
       request = JSON.parse request_json, symbolize_names: true
-      response = handle request, &method_finder
+      response = handle request, id_validation_pattern:, &method_finder
     rescue JSON::ParserError
-      response =error_response id: :unknown_id, error: {
+      response = error_response id: :unknown_id, id_validation_pattern:, error: {
         code: ErrorCode::ParseError,
         message: 'Parse error',
         data: 'Invalid JSON',
@@ -62,16 +65,16 @@ module JsonRpcHandler
     response.to_json if response
   end
 
-  def process_request(request, &method_finder)
+  def process_request(request, id_validation_pattern:, &method_finder)
     id = request[:id]
 
     error = case
       when !valid_version?(request[:jsonrpc]) then 'JSON-RPC version must be 2.0'
-      when !valid_id?(request[:id]) then 'Request ID must be a string or an integer or null'
+      when !valid_id?(request[:id], id_validation_pattern) then 'Request ID must match validation pattern, or be an integer or null'
       when !valid_method_name?(request[:method]) then 'Method name must be a string and not start with "rpc."'
     end
 
-    return error_response id: :unknown_id, error: {
+    return error_response id: :unknown_id, id_validation_pattern:, error: {
       code: ErrorCode::InvalidRequest,
       message: 'Invalid Request',
       data: error,
@@ -81,7 +84,7 @@ module JsonRpcHandler
     params = request[:params]
 
     unless valid_params? params
-      return error_response id:, error: {
+      return error_response id:, id_validation_pattern:, error: {
         code: ErrorCode::InvalidParams,
         message: 'Invalid params',
         data: 'Method parameters must be an array or an object or null',
@@ -92,7 +95,7 @@ module JsonRpcHandler
       method = method_finder.call method_name
 
       if method.nil?
-        return error_response id:, error: {
+        return error_response id:, id_validation_pattern:, error: {
           code: ErrorCode::MethodNotFound,
           message: 'Method not found',
           data: method_name,
@@ -103,7 +106,7 @@ module JsonRpcHandler
 
       success_response id:, result:
     rescue StandardError => e
-      error_response id:, error: {
+      error_response id:, id_validation_pattern:, error: {
         code: ErrorCode::InternalError,
         message: 'Internal error',
         data: e.message,
@@ -115,8 +118,12 @@ module JsonRpcHandler
     version == Version::V2_0
   end
 
-  def valid_id?(id)
-    id.is_a?(String) || id.is_a?(Integer) || id.nil?
+
+  def valid_id?(id, pattern = nil)
+    return true if id.nil? || id.is_a?(Integer)
+    return false unless id.is_a?(String)
+
+    pattern ? id.match?(pattern) : true
   end
 
   def valid_method_name?(method)
@@ -135,10 +142,10 @@ module JsonRpcHandler
     } unless id.nil?
   end
 
-  def error_response(id:, error:)
+  def error_response(id:, id_validation_pattern:, error:)
     {
       jsonrpc: Version::V2_0,
-      id: valid_id?(id) ? id : nil,
+      id: valid_id?(id, id_validation_pattern) ? id : nil,
       error: error.compact,
     } unless id.nil?
   end

--- a/test/json_rpc_handler_test.rb
+++ b/test/json_rpc_handler_test.rb
@@ -90,9 +90,9 @@ describe JsonRpcHandler do
     #   The Server MUST reply with the same value in the Response object if included. This member is used to correlate the
     #   context between the two objects.
 
-    it "returns a response with the same request id when the id is a string" do
+    it "returns a response with the same request id when the id is a valid string" do
       register("add") { |params| params[:a] + params[:b] }
-      id = "rpc-call-42"
+      id = "request-123_abc"
 
       handle jsonrpc: "2.0", id:, method: "add", params: { a: 1, b: 2 }
 
@@ -116,7 +116,67 @@ describe JsonRpcHandler do
       assert_rpc_error expected_error: {
         code: -32600,
         message: "Invalid Request",
-        data: "Request ID must be a string or an integer or null",
+        data: "Request ID must match validation pattern, or be an integer or null",
+      }
+    end
+
+    it "accepts string id with alphanumerics, dashes, and underscores" do
+      register("add") { |params| params[:a] + params[:b] }
+      id = "request-123_ABC"
+
+      handle jsonrpc: "2.0", id:, method: "add", params: { a: 1, b: 2 }
+
+      assert_rpc_success expected_result: 3
+      assert_equal id, @response[:id]
+    end
+
+    it "accepts UUID format strings" do
+      register("add") { |params| params[:a] + params[:b] }
+      id = "550e8400-e29b-41d4-a716-446655440000"
+
+      handle jsonrpc: "2.0", id:, method: "add", params: { a: 1, b: 2 }
+
+      assert_rpc_success expected_result: 3
+      assert_equal id, @response[:id]
+    end
+
+    it "returns an error when request id contains HTML content (XSS prevention)" do
+      handle jsonrpc: "2.0", id: "<script>alert('xss')</script>", method: "add", params: { a: 1, b: 2 }
+
+      assert_rpc_error expected_error: {
+        code: -32600,
+        message: "Invalid Request",
+        data: "Request ID must match validation pattern, or be an integer or null",
+      }
+    end
+
+    it "returns an error when request id contains spaces" do
+      handle jsonrpc: "2.0", id: "request 123", method: "add", params: { a: 1, b: 2 }
+
+      assert_rpc_error expected_error: {
+        code: -32600,
+        message: "Invalid Request",
+        data: "Request ID must match validation pattern, or be an integer or null",
+      }
+    end
+
+    it "returns an error when request id contains special characters" do
+      handle jsonrpc: "2.0", id: "request@123", method: "add", params: { a: 1, b: 2 }
+
+      assert_rpc_error expected_error: {
+        code: -32600,
+        message: "Invalid Request",
+        data: "Request ID must match validation pattern, or be an integer or null",
+      }
+    end
+
+    it "returns an error when request id is an empty string" do
+      handle jsonrpc: "2.0", id: "", method: "add", params: { a: 1, b: 2 }
+
+      assert_rpc_error expected_error: {
+        code: -32600,
+        message: "Invalid Request",
+        data: "Request ID must match validation pattern, or be an integer or null",
       }
     end
 
@@ -126,7 +186,7 @@ describe JsonRpcHandler do
       assert_rpc_error expected_error: {
         code: -32600,
         message: "Invalid Request",
-        data: "Request ID must be a string or an integer or null",
+        data: "Request ID must match validation pattern, or be an integer or null",
       }
     end
 
@@ -250,7 +310,7 @@ describe JsonRpcHandler do
       assert_rpc_error expected_error: {
         code: -32600,
         message: "Invalid Request",
-        data: "Request ID must be a string or an integer or null",
+        data: "Request ID must match validation pattern, or be an integer or null",
       }
       assert_nil @response[:id]
     end
@@ -432,6 +492,125 @@ describe JsonRpcHandler do
     #
     # Method names that begin with rpc. are reserved for system extensions, and MUST NOT be used for anything else. Each
     # system extension is defined in a related specification. All system extensions are OPTIONAL.
+
+    describe "ID pattern configuration" do
+      it "uses the default pattern by default" do
+        register("add") { |params| params[:a] + params[:b] }
+
+        handle jsonrpc: "2.0", id: "valid-id_123", method: "add", params: { a: 1, b: 2 }
+
+        assert_rpc_success expected_result: 3
+      end
+
+      it "rejects IDs that don't match the default pattern" do
+        handle jsonrpc: "2.0", id: "invalid@id", method: "add", params: { a: 1, b: 2 }
+
+        assert_rpc_error expected_error: {
+          code: -32600,
+          message: "Invalid Request",
+          data: "Request ID must match validation pattern, or be an integer or null",
+        }
+      end
+
+      it "uses default pattern and rejects @ signs" do
+        register("add") { |params| params[:a] + params[:b] }
+
+        # Default pattern should reject @ signs
+        handle jsonrpc: "2.0", id: "user@example.com", method: "add", params: { a: 1, b: 2 }
+
+        assert_rpc_error expected_error: {
+          code: -32600,
+          message: "Invalid Request",
+          data: "Request ID must match validation pattern, or be an integer or null",
+        }
+      end
+
+      it "accepts custom pattern as parameter to handle" do
+        register("add") { |params| params[:a] + params[:b] }
+        custom_pattern = /\A[a-zA-Z0-9_.\-@]+\z/
+
+        @response = JsonRpcHandler.handle(
+          { jsonrpc: "2.0", id: "user@example.com", method: "add", params: { a: 1, b: 2 } },
+          id_validation_pattern: custom_pattern
+        ) { |method_name| @registry[method_name] }
+
+        assert_rpc_success expected_result: 3
+        assert_equal "user@example.com", @response[:id]
+      end
+
+      it "validates against custom pattern parameter" do
+        custom_pattern = /\A[a-zA-Z0-9_.\-@]+\z/
+
+        @response = JsonRpcHandler.handle(
+          { jsonrpc: "2.0", id: "id<script>", method: "add", params: { a: 1, b: 2 } },
+          id_validation_pattern: custom_pattern
+        ) { |method_name| @registry[method_name] }
+
+        assert_rpc_error expected_error: {
+          code: -32600,
+          message: "Invalid Request",
+          data: "Request ID must match validation pattern, or be an integer or null",
+        }
+      end
+
+      it "accepts custom pattern as parameter to handle_json" do
+        register("add") { |params| params[:a] + params[:b] }
+        custom_pattern = /\A[a-zA-Z0-9_.\-@]+\z/
+
+        @response_json = JsonRpcHandler.handle_json(
+          { jsonrpc: "2.0", id: "user@example.com", method: "add", params: { a: 1, b: 2 } }.to_json,
+          id_validation_pattern: custom_pattern
+        ) { |method_name| @registry[method_name] }
+        @response = JSON.parse(@response_json, symbolize_names: true)
+
+        assert_rpc_success expected_result: 3
+        assert_equal "user@example.com", @response[:id]
+      end
+
+      it "applies custom pattern to batch requests" do
+        register("add") { |params| params[:a] + params[:b] }
+        register("mul") { |params| params[:a] * params[:b] }
+        custom_pattern = /\A[a-zA-Z0-9_.\-@]+\z/
+
+        @response = JsonRpcHandler.handle(
+          [
+            { jsonrpc: "2.0", id: "req@1", method: "add", params: { a: 1, b: 2 } },
+            { jsonrpc: "2.0", id: "req@2", method: "mul", params: { a: 3, b: 4 } },
+          ],
+          id_validation_pattern: custom_pattern
+        ) { |method_name| @registry[method_name] }
+
+        assert @response.is_a?(Array)
+        assert_equal ["req@1", "req@2"], @response.map { |r| r[:id] }
+        assert_equal [3, 12], @response.map { |r| r[:result] }
+      end
+
+      it "parameter pattern overrides default pattern" do
+        register("add") { |params| params[:a] + params[:b] }
+        # Use permissive parameter pattern (default is restrictive)
+        custom_pattern = /\A[a-zA-Z0-9_.\-@]+\z/
+
+        @response = JsonRpcHandler.handle(
+          { jsonrpc: "2.0", id: "user@example.com", method: "add", params: { a: 1, b: 2 } },
+          id_validation_pattern: custom_pattern
+        ) { |method_name| @registry[method_name] }
+
+        assert_rpc_success expected_result: 3
+        assert_equal "user@example.com", @response[:id]
+      end
+
+      it "accepts any string when pattern is nil" do
+        register("add") { |params| params[:a] + params[:b] }
+
+        @response = JsonRpcHandler.handle(
+          { jsonrpc: "2.0", id: "<script>alert('xss')</script>", method: "add", params: { a: 1, b: 2 } },
+          id_validation_pattern: nil
+        ) { |method_name| @registry[method_name] }
+
+        assert_rpc_success expected_result: 3
+        assert_equal "<script>alert('xss')</script>", @response[:id]
+      end
+    end
   end
 
   describe '#handle_json' do


### PR DESCRIPTION
# Add ID validation to prevent XSS vulnerabilities

This PR adds string ID validation to protect against XSS vulnerabilities when request IDs are reflected in responses. By default, string IDs are now validated to contain only alphanumeric characters, dashes, and underscores; this prevents users from sending HTML content that is reflected back in responses. Reflecting raw ids with HTML content in responses opens a vector for XSS if proper content type validations are not also applied.

The validation pattern can be customized by passing an `id_validation_pattern` parameter to `handle` or `handle_json` methods:

- Default pattern: `/\A[a-zA-Z0-9_-]+\z/`
- Custom pattern: Pass any regex pattern to allow different characters
- Disable validation: Pass `nil` to accept any string ID (not recommended)

The README has been updated with examples showing how to use and customize the ID validation.